### PR TITLE
Add sample e2e test and reorganize role controller unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   - [**Setting up Environment**](#setting-up-environment)
   - [**Deploying Locally**](#deploying-locally)
   - [**Verifying through Postman Collections**](#verifying-through-postman-collections)
+  - [**Running Tests**](#running-tests)
   - [**Environment Configuration**](#environment-configuration)
 
 **Prerequisites**
@@ -64,6 +65,23 @@ pnpm run prisma:migrate:group
 ```bash
 pnpm run start:dev
 ```
+**Running Tests**
+-----------------
+
+Unit and end-to-end tests are implemented using Jest. After installing dependencies you can execute:
+
+```bash
+pnpm test
+```
+
+This command runs all unit tests under `test/unit` as well as any end-to-end tests under `test/e2e`.
+
+To generate a coverage report run:
+
+```bash
+pnpm test:cov
+```
+
 **Verifying through Postman Collections**
 --------------------------------------
 

--- a/package.json
+++ b/package.json
@@ -104,16 +104,20 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
+    "rootDir": ".",
+    "testMatch": [
+      "<rootDir>/src/**/*.spec.ts",
+      "<rootDir>/test/**/*.spec.ts"
+    ],
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
     "collectCoverageFrom": [
-      "**/*.(t|j)s",
-      "!api/**/*.module.ts"
+      "src/**/*.(t|j)s",
+      "!src/api/**/*.module.ts",
+      "test/**/*.(t|j)s"
     ],
-    "coverageDirectory": "../coverage",
+    "coverageDirectory": "coverage",
     "testEnvironment": "node"
   }
 }

--- a/test/e2e/role.e2e-spec.ts
+++ b/test/e2e/role.e2e-spec.ts
@@ -1,0 +1,44 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { RoleController } from '../../src/api/role/role.controller';
+import { RoleService } from '../../src/api/role/role.service';
+import { AuthGuard } from '@nestjs/passport';
+
+describe('RoleController (e2e)', () => {
+  let app: INestApplication;
+  const roleService = {
+    findAll: jest.fn().mockResolvedValue([{ roleId: 1, roleName: 'admin' }]),
+  } as Partial<RoleService>;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [RoleController],
+      providers: [{ provide: RoleService, useValue: roleService }],
+    })
+      .overrideGuard(AuthGuard('jwt'))
+      .useValue({
+        canActivate: (context: any) => {
+          const req = context.switchToHttp().getRequest();
+          req.user = { userId: '1', isAdmin: true };
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/roles (GET)', async () => {
+    await request(app.getHttpServer())
+      .get('/roles?filter=subjectId=1')
+      .expect(200)
+      .expect([{ roleId: 1, roleName: 'admin' }]);
+    expect(roleService.findAll).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/unit/api/role/role.controller.spec.ts
+++ b/test/unit/api/role/role.controller.spec.ts
@@ -1,18 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { RoleController } from './role.controller';
-import { RoleService } from './role.service';
+import { RoleController } from '../../../../src/api/role/role.controller';
+import { RoleService } from '../../../../src/api/role/role.service';
 import { AuthGuard } from '@nestjs/passport';
 import {
   ForbiddenException,
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { AuthenticatedUser } from '../../core/auth/jwt.strategy';
+import { AuthenticatedUser } from '../../../../src/core/auth/jwt.strategy';
 import {
   RoleResponseDto,
   CreateRoleBodyDto,
   UpdateRoleBodyDto,
-} from '../../dto/role/role.dto';
+} from '../../../../src/dto/role/role.dto';
 
 // Mock RoleService
 const mockRoleService: jest.Mocked<Partial<RoleService>> = {


### PR DESCRIPTION
## Summary
- move role controller unit test under `test/unit`
- add example e2e test for roles endpoint
- update jest config and docs to support new test locations

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893a7355db083269a93369c87aab7c3