### PR TITLE
fix: handle null data in response builder

### DIFF
--- a/src/shared/util/responseBuilder.spec.ts
+++ b/src/shared/util/responseBuilder.spec.ts
@@ -1,0 +1,17 @@
+import { createBaseResponse } from './responseBuilder';
+import { HttpStatus } from '@nestjs/common';
+
+describe('responseBuilder', () => {
+  it('should handle null data when fields are specified', () => {
+    const result = createBaseResponse(null, HttpStatus.OK, 'id');
+    expect(result).toEqual({
+      result: {
+        success: true,
+        status: HttpStatus.OK,
+        metadata: null,
+        content: null,
+      },
+      version: 'v3',
+    });
+  });
+});

--- a/src/shared/util/responseBuilder.ts
+++ b/src/shared/util/responseBuilder.ts
@@ -10,7 +10,7 @@ export interface BaseResponse<T> {
   version: string;
 }
 
-export function createBaseResponse<T extends object>(
+export function createBaseResponse<T extends object | null>(
   data: T,
   status = HttpStatus.OK,
   fields?: string,
@@ -41,11 +41,14 @@ export function createErrorResponse(
   };
 }
 
-export function filterFieldsNested<T extends object>(
+export function filterFieldsNested<T extends object | null>(
   data: T,
   fields?: string,
   excludeFields?: string[],
 ): any {
+  if (data == null) {
+    return data;
+  }
   const parsedFields = fields
     ?.split(',')
     .map((f) => f.trim())


### PR DESCRIPTION
## Summary
- allow response builder utilities to accept null objects
- guard against null when filtering nested fields
- cover response builder for null data in new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a715e19c8326a073391d7177a3dd